### PR TITLE
Drupal php7

### DIFF
--- a/common/defaults/main.yml
+++ b/common/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+passauth: "False"

--- a/common/tasks/main.yml
+++ b/common/tasks/main.yml
@@ -33,6 +33,6 @@
     name: rsyslog
     state: restarted
     enabled: yes
-
-#- include: nopasswordauth.yaml
-#  when: passauth == 'True'
+    
+- include: nopasswordauth.yaml
+  when: passauth == 'False'

--- a/common/tasks/main.yml
+++ b/common/tasks/main.yml
@@ -34,5 +34,5 @@
     state: restarted
     enabled: yes
 
-- include: nopasswordauth.yaml
-  when: passauth == 'True'
+#- include: nopasswordauth.yaml
+#  when: passauth == 'True'

--- a/common/vars/RedHat.yml
+++ b/common/vars/RedHat.yml
@@ -2,6 +2,6 @@
 common_packages:
   - libselinux-python
   - epel-release
-  - ntp
+  - chrony
 
-ntp_service: ntpd
+ntp_service: chronyd

--- a/nginx/templates/Common/default_vhost.conf.j2
+++ b/nginx/templates/Common/default_vhost.conf.j2
@@ -54,8 +54,8 @@ server {
   location ~ .php$ {
     try_files $uri /index.php;
     expires off;
-#    fastcgi_pass unix:/var/run/php-fpm/{{ item.name }}.sock;
-    fastcgi_pass 127.0.0.1:80{{ item.http_port }};
+    fastcgi_pass unix:/run/php-fpm/{{ item.name }}.sock;
+#     fastcgi_pass 127.0.0.1:80{{ item.http_port }};
     fastcgi_buffers 256 4k;
     fastcgi_buffer_size 32k;
     fastcgi_busy_buffers_size 256k;

--- a/nginx/templates/Common/drupal_secondary_vhost.conf.j2
+++ b/nginx/templates/Common/drupal_secondary_vhost.conf.j2
@@ -73,8 +73,8 @@ server {
   location ~ .php$ {
     try_files $uri /index.php;
     expires off;
-#    fastcgi_pass unix:/var/run/php-fpm/{{ item.name }}.sock;
-    fastcgi_pass 127.0.0.1:80{{ item.http_port }};
+    fastcgi_pass unix:/run/php-fpm/{{ item.name }}.sock;
+#     fastcgi_pass 127.0.0.1:80{{ item.http_port }};
     fastcgi_buffers 256 4k;
     fastcgi_buffer_size 32k;
     fastcgi_busy_buffers_size 256k;

--- a/nginx/templates/Common/drupal_vhost.conf.j2
+++ b/nginx/templates/Common/drupal_vhost.conf.j2
@@ -70,8 +70,8 @@ server {
   location ~ .php$ {
     try_files $uri /index.php;
     expires off;
-#    fastcgi_pass unix:/var/run/php-fpm/{{ item.name }}.sock;
-    fastcgi_pass 127.0.0.1:80{{ item.http_port }};
+    fastcgi_pass unix:/run/php-fpm/{{ item.name }}.sock;
+#     fastcgi_pass 127.0.0.1:80{{ item.http_port }};
     fastcgi_buffers 256 4k;
     fastcgi_buffer_size 32k;
     fastcgi_busy_buffers_size 256k;

--- a/php-fpm/defaults/main.yml
+++ b/php-fpm/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+tz: 'Etc/UTC'
+
 phpfpm_start_servers: 20
 phpfpm_min_spare_servers: 20
 phpfpm_max_spare_servers: 30

--- a/php-fpm/templates/Common/vhost.conf.j2
+++ b/php-fpm/templates/Common/vhost.conf.j2
@@ -11,10 +11,12 @@
 
 [{{ item.name }}]
 
-listen = 127.0.0.1:80{{ item.http_port }}
+; listen = 127.0.0.1:80{{ item.http_port }}
 
 
-listen.allowed_clients = 127.0.0.1
+; listen.allowed_clients = 127.0.0.1
+
+listen = /run/php-fpm/{{ item.name }}.sock
 listen.owner = {{ item.phpfpm_user }}
 listen.group = nginx
 listen.mode = 0660

--- a/php/defaults/main.yml
+++ b/php/defaults/main.yml
@@ -2,3 +2,5 @@
 tz: 'America/Chicago'
 
 phpfpm_vers: "php73"
+
+php_opcache_memory_consumption: "256"

--- a/php/tasks/main.yml
+++ b/php/tasks/main.yml
@@ -11,6 +11,14 @@
     dest: "{{ item.dest }}"
   with_items: "{{ php_modules_config }}"
 
+- name: Optimize opcache module
+  ini_file:
+    dest: "{{ php_modules_config_root }}/opcache.ini"
+    section: null
+    option: opcache.memory_consumption
+    value: "{{ php_opcache_memory_consumption }}"
+    state: present
+
 - name: Restart Apache
   service:
     name: "{{ apache_pkg }}"

--- a/php/vars/RedHat.yml
+++ b/php/vars/RedHat.yml
@@ -6,6 +6,7 @@ php_modules: [
 "{{ phpfpm_vers }}-pdo",
 "{{ phpfpm_vers }}-gd",
 "{{ phpfpm_vers }}-mysqlnd",
+"{{ phpfpm_vers }}-opcache",
 #"{{ phpfpm_vers }}-mcrypt",
 "{{ phpfpm_vers }}-xml",
 "{{ phpfpm_vers }}-xmlrpc",

--- a/php/vars/RedHat.yml
+++ b/php/vars/RedHat.yml
@@ -21,8 +21,8 @@ php_modules: [
 php_modules_config:
   - src: php.ini.j2
     dest: /etc/php.ini
-  - src: opcache.ini.j2
-    dest: "{{ php_modules_config_root }}/opcache.ini"
+#  - src: opcache.ini.j2
+#    dest: "{{ php_modules_config_root }}/opcache.ini"
   - src: redis.ini.j2
     dest: "{{ php_modules_config_root }}/redis.ini"
 


### PR DESCRIPTION
Drupal role uses PHP7, as a result it can install the latest Drupal (Drupal 8) on both Ubuntu and CentOS. Also switched to UNIX sockets for nginx (higher performance)